### PR TITLE
Resolves #7 - Pass list of query files in callback/resolve

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -12,7 +12,7 @@ export interface ILoadQueryCallback {
 }
 
 export interface IValidateCallback {
-  (errors?: IQueryFileError[], results?)
+  (errors?: IQueryFileError[], results?: DocumentNode[])
 }
 
 export function validateQuery(schema: GraphQLSchema, document: DocumentNode): GraphQLError[] {
@@ -54,7 +54,7 @@ export function validateQueryFiles(glob: string, schema: GraphQLSchema,
         if (errors.length) {
           callback ? callback(errors) : reject(errors)
         } else {
-          callback ? callback() : resolve()
+          callback ? callback(null, queries) : resolve(queries)
         }
       })
       .catch((err) => {

--- a/src/test/index.test.ts
+++ b/src/test/index.test.ts
@@ -225,11 +225,17 @@ describe('GraphQL Validator', () => {
       })
 
       it('expect results to be empty', (done) => {
-        expect(results).to.be.undefined
+        expect(results).to.be.instanceOf(Array)
+            .and.to.have.length(2)
+            .and.to.contain('./fixtures/queries/allFilms.graphql')
+            .and.to.contain('./fixtures/queries/allPeople.graphql')
         done()
       })
       it('expect callback results to be empty', (done) => {
-        expect(results).to.be.undefined
+        expect(cbResults).to.be.instanceOf(Array)
+            .and.to.have.length(2)
+            .and.to.contain('./fixtures/queries/allFilms.graphql')
+            .and.to.contain('./fixtures/queries/allPeople.graphql')
         done()
       })
     })


### PR DESCRIPTION
Resolve `validateQueryFiles` with the list of queries validated to enable assertions on for instance the number of queries expected to have been validated.